### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -8,6 +8,7 @@
   ],
   "description" : "XPath perl6 library",
   "name" : "XML::XPath",
+  "license" : "Artistic-2.0",
   "perl" : "6.c",
   "tags" : ["XML", "XPath", "Parsing", "W3C", "Query Language"],
   "provides" : {


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license