### PR TITLE
Flatten result of `find` when `:to-list` set. fixes #4

### DIFF
--- a/lib/XML/XPath.pm6
+++ b/lib/XML/XPath.pm6
@@ -30,7 +30,7 @@ class XML::XPath {
         unless $to-list {
             return unwrap $result, :to-nil(True);
         }
-        return $result;
+        return $result.flat;
     }
 
     method parse-xpath(Str $xpath) {

--- a/t/49_flat_to_list.t
+++ b/t/49_flat_to_list.t
@@ -1,0 +1,10 @@
+use v6.c;
+
+use Test;
+use XML::XPath;
+
+my $x = XML::XPath.new( xml => '<foo><bar/><bar/></foo>');
+is-deeply $x.find('/foo/bar', :to-list), $x.find('/foo/bar', :to-list).flat, 'is not item context';
+
+done-testing;
+


### PR DESCRIPTION
`find` was returning an item context when `:to-list` was specified. This
caused iterations to iterate over an item contextualized Array instead
of the elements of the Array.